### PR TITLE
Change the way buffers are allocated (Buffer.alloc() iso new Buffer()).

### DIFF
--- a/lib/struct.js
+++ b/lib/struct.js
@@ -86,7 +86,7 @@ function Struct () {
       arg = data
     } else {
       debug('creating new Buffer instance to back the struct (size: %d)', StructType.size)
-      store = new Buffer(StructType.size)
+      store = Buffer.alloc(StructType.size)
     }
 
     // set the backing Buffer store

--- a/test/struct.js
+++ b/test/struct.js
@@ -121,7 +121,7 @@ describe('Struct', function () {
         'ptr2': 'void *'
       })
       var s = new S()
-      var b = new Buffer(1)
+      var b = Buffer.alloc(1)
       s.ptr1 = ref.NULL
       s.ptr2 = b
       assert.equal(ref.NULL.address(), s.ptr1.address())
@@ -138,7 +138,7 @@ describe('Struct', function () {
         test2: ref.types.int
       });
 
-      var b = new Buffer(Foo.size * 2);
+      var b = Buffer.alloc(Foo.size * 2);
 
       Foo.set(b, Foo.size * 0, {
         test1: 7123,
@@ -166,7 +166,7 @@ describe('Struct', function () {
         test2: ref.types.int
       });
 
-      var b = new Buffer(Foo.size * 2);
+      var b = Buffer.alloc(Foo.size * 2);
 
       Foo.set(b, Foo.size * 0, new Foo({
         test1: 7123,


### PR DESCRIPTION
Please update the library, since the usage of new Buffer is deprecated.